### PR TITLE
Fix value error in dataset module

### DIFF
--- a/openspeech/data/audio/dataset.py
+++ b/openspeech/data/audio/dataset.py
@@ -139,7 +139,12 @@ class SpeechToTextDataset(Dataset):
 
         tmp = list(zip(self.audio_paths, self.transcripts, self.augments))
         random.shuffle(tmp)
-        self.audio_paths, self.transcripts, self.augments = zip(*tmp)
+        
+        for i, x in enumerate(tmp):
+            self.audio_paths[i] = x[0]
+            self.transcripts[i] = x[1]
+            self.augments[i] = x[2]
+
 
     def _parse_audio(self, audio_path: str, augment: int = None, joining_idx: int = 0) -> Tensor:
         """


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fix value error when it do unpack. I referred here: https://github.com/sooftware/kospeech/issues/145

"""
Traceback (most recent call last):
File "./openspeech_cli/hydra_train.py", line 48, in hydra_main
data_module.setup()
File "/home/roytravel/github/openspeech/openspeech/datasets/ksponspeech/lit_data_module.py", line 171, in setup
del_silence=self.configs.audio.del_silence if stage == 'train' else False,
File "/home/roytravel/github/openspeech/openspeech/data/audio/dataset.py", line 142, in init
self.audio_paths, self.transcripts, self.augments = zip(*tmp)
ValueError: not enough values to unpack (expected 3, got 0)
"""


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag