### PR TITLE
Update utils.py to handle exception when pytorch_lightning >= 1.9

### DIFF
--- a/openspeech/utils.py
+++ b/openspeech/utils.py
@@ -82,7 +82,11 @@ try:
     import pytorch_lightning as pl
     from pytorch_lightning.loggers import LightningLoggerBase, TensorBoardLogger, WandbLogger
 except ImportError:
-    raise ValueError(PYTORCH_LIGHTNING_IMPORT_ERROR)
+    try:
+        from pytorch_lightning.loggers import Logger, TensorBoardLogger, WandbLogger
+        LightningLoggerBase = Logger
+    except ImportError:
+        raise ValueError(PYTORCH_LIGHTNING_IMPORT_ERROR)
 
 DUMMY_SIGNALS, _ = librosa.load(librosa.ex("choice"))
 DUMMY_FEATURES = librosa.feature.melspectrogram(DUMMY_SIGNALS, n_mels=80)


### PR DESCRIPTION
# What does this PR do?

I started openspeech as follow: 
```python
python3 ./openspeech_cli/hydra_train.py dataset=ksponspeech dataset.dataset_path=/workspace/data dataset.manifest_file_path=/workspace/data/transcripts.txt tokenizer=kspon_character model=conformer_lstm audio=fbank lr_scheduler=warmup_reduce_lr_on_plateau trainer=gpu criterion=cross_entropy
```

This error occured directly:
```
ImportError: cannot import name 'LightningLoggerBase' from 'pytorch_lightning.loggers' (/root/anaconda3/envs/mirae/lib/python3.8/site-packages/pytorch_lightning/loggers/__init__.py)
```

Fixes #212 Import error of pytorch_lightning LightningLoggerBase


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
  - I did testing on my environment. After applying this code, the error is removed.

[Cannot import name 'LightningLoggerBase' from 'pytorch_lightning.loggers' #962](https://github.com/Lightning-Universe/lightning-bolts/issues/962) <-- this issue shows information that LightingLoggerBase transfers into Logger when version begins >=1.9


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag